### PR TITLE
arrow border is a little distracting, removing the arrow

### DIFF
--- a/packages/react-app/src/components/SystemFeedback.jsx
+++ b/packages/react-app/src/components/SystemFeedback.jsx
@@ -2,7 +2,6 @@ import {
   Flex,
   Image,
   Popover,
-  PopoverArrow,
   PopoverBody,
   PopoverContent,
   PopoverTrigger,
@@ -38,7 +37,6 @@ export const SystemFeedback = () => {
         maxW="30rem"
         // _focus={{ border: 'none', outline: 'none' }}
       >
-        <PopoverArrow />
         {token && (
           <PopoverBody width="100%" align="center" fontSize="sm">
             <Flex align="center" justify="space-between">


### PR DESCRIPTION
[issue](https://github.com/raid-guild/xdai-omnibridge/issues/84)

### Problem
The popover arrow has an odd box shadow contrast to the popover box that holds the content

### Solution
I opted to just remove the the arrow to simply things

### this

<img width="349" alt="Screen Shot 2020-09-20 at 3 33 51 PM" src="https://user-images.githubusercontent.com/5998100/93726538-6c950780-fb6b-11ea-8e7a-aa53a3b0d822.png">


### vs this:

<img width="406" alt="Screen Shot 2020-09-20 at 5 55 31 PM" src="https://user-images.githubusercontent.com/5998100/93726503-3c4d6900-fb6b-11ea-9c69-317276d68bb5.png">

thoughts?